### PR TITLE
fix misplaced entry when opening day at end of month

### DIFF
--- a/journal.cpp
+++ b/journal.cpp
@@ -63,6 +63,7 @@ int journal_timestamp_open(char path[],tm target_time, tm journal_time){
 	if (mktime(&target_time) != mktime(&journal_time))
 	{
 		target_time.tm_mday += 1;
+		mktime(&target_time);
 		char entry_date[] = "1969-12-31";
 		strftime(entry_date, strlen("1970-01-01"), "%F", &target_time); //String is entry date plus one
 		entry_pos = journal_text.rfind(entry_date, journal_text.length());


### PR DESCRIPTION
When opening the journal at the end of the month, the timestamp is incorrectly placed at the end of the journal file rather than under the corresponding date. 

The issue is caused by an incorrectly formatted time object. In order to find the location to place the time stamp the program finds the date immediately after the desired date, and places the timestamp just before this header. It finds the date immediately after the desired date by adding one to the days component of the date. When at the end of the month this results in an illogical state for the date, which causes the finding of the header to fail. 

This is resolved by using mktime to adjust the values to represent a valid date.